### PR TITLE
Patching will now forcefully close any "ghosted" launcher

### DIFF
--- a/Renegade X Launcher/App.xaml.cs
+++ b/Renegade X Launcher/App.xaml.cs
@@ -46,6 +46,10 @@ namespace LauncherTwo
                 }
                 else if(a.StartsWith("--UpdateGame="))//Manually opdate the game to a given URL.
                 {
+                    // Close any other instances of the RenX-Launcher
+                    if ( InstanceHandler.IsAnotherInstanceRunning() )
+                        InstanceHandler.KillDuplicateInstance();
+
                     var targetDir = GameInstallation.GetRootPath();
                     var applicationDir = System.IO.Path.Combine(GameInstallation.GetRootPath(), "patch");
                     String patchUrl = a.Substring("--UpdateGame=".Length);
@@ -85,6 +89,13 @@ namespace LauncherTwo
             //If no args are present, or a permissionChange update was executed -> normally start the launcher
             if (e.Args.Length == 0 || isGoodUpdate)
             {
+                if (InstanceHandler.IsAnotherInstanceRunning())
+                {
+                    MessageBox.Show("Error:\nUnable to start Renegade-X Launcher: Another instance is already running!",
+                        "Renegade-X Launcher", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
+                    Current.Shutdown();
+                }
+
                 new MainWindow().Show();
             }
             /*else

--- a/Renegade X Launcher/InstanceHandler.cs
+++ b/Renegade X Launcher/InstanceHandler.cs
@@ -1,0 +1,60 @@
+﻿// AX
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LauncherTwo
+{
+    /*
+     * InstanceHandler class
+     * What Does It Do
+     *  This class attempts to find other running instances of the launcher running in the same directory.
+     */
+    static class InstanceHandler
+    {
+        public static bool IsAnotherInstanceRunning()
+        {
+            try
+            {
+                var CurrentRunningApplicationPath = System.Reflection.Assembly.GetEntryAssembly().Location;
+                var CurrentRunningApplicationName = Path.GetFileName(CurrentRunningApplicationPath).Replace(".exe", "");
+                var CurrentProc = Process.GetCurrentProcess();
+
+                var processList = Process.GetProcessesByName(CurrentRunningApplicationName);
+
+                // If we have another process that does not have the same PID and is running from the same directory, then we have a match
+                return processList.Any(process => process.MainModule.FileName == CurrentRunningApplicationPath && process.Id != CurrentProc.Id);
+            } catch { 
+                return false;
+            }
+        }
+
+        /*
+         * Kills a "ghosted" process if the process is from the same directory as the current instance
+         *  Helps with updater errors when a file lock is open on a file attempting to be updated.
+         */
+        public static void KillDuplicateInstance()
+        {
+            try
+            {
+                var CurrentRunningApplicationPath = System.Reflection.Assembly.GetEntryAssembly().Location;
+                var CurrentRunningApplicationName = Path.GetFileName(CurrentRunningApplicationPath).Replace(".exe", "");
+                var CurrentProc = Process.GetCurrentProcess();
+
+                var processList = Process.GetProcessesByName(CurrentRunningApplicationName);
+
+                // If we have another process that does not have the same PID and is running from the same directory, then we have a match
+                var ourProcess = processList.DefaultIfEmpty(null).FirstOrDefault(x => x.MainModule.FileName == CurrentRunningApplicationPath && x.Id != CurrentProc.Id);
+                ourProcess?.Kill();
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/Renegade X Launcher/MainWindow.xaml.cs
+++ b/Renegade X Launcher/MainWindow.xaml.cs
@@ -217,6 +217,10 @@ namespace LauncherTwo
             }
             else
             {
+                // Close any other instances of the RenX-Launcher
+                if (InstanceHandler.IsAnotherInstanceRunning())
+                    InstanceHandler.KillDuplicateInstance();
+
                 var targetDir = GameInstallation.GetRootPath();
                 var applicationDir = Path.Combine(GameInstallation.GetRootPath(), "patch");
                 var patchPath = VersionCheck.GamePatchPath;


### PR DESCRIPTION
Please note:
This will only close any ghosted renx launchers that are from the same directory.

Also, this commit does not allow multiple launchers to be started from the same working directory.