### PR TITLE
Usernames may now contain spaces

### DIFF
--- a/Renegade X Launcher/LaunchTools.cs
+++ b/Renegade X Launcher/LaunchTools.cs
@@ -60,13 +60,7 @@ namespace LauncherTwo
                 arguments += " -nomoviestartup"; 
             }
 
-            //Pinpoint location of quote error
-            //Arguments += " -ini:UDKGame:DefaultPlayer.Name=\"" + Username + "\"";
-            //End quote error
-
-            //Fix for quote error
-            arguments += " -ini:UDKGame:DefaultPlayer.Name=" + Username + "";
-            //End Fix
+            arguments += " -ini:UDKGame:DefaultPlayer.Name=" + Username.Replace(' ', '\u00A0');
             return arguments;
         }
 


### PR DESCRIPTION
Usernames may now contain spaces. This works by replacing input space characters (`\u0032`) with non-breaking space characters (`\u00A0`), which causes the string to be handled as a single word.