### PR TITLE
Fix server launch button

### DIFF
--- a/Renegade X Launcher/LaunchTools.cs
+++ b/Renegade X Launcher/LaunchTools.cs
@@ -33,7 +33,7 @@ namespace LauncherTwo
     {
         public override string GetProcessArguments()
         {
-            return "server CNC-Walls_Flying -nosteam";
+            return "server CNC-Walls -nosteam";
         }
     }
 


### PR DESCRIPTION
The server launch button would try and start Walls_Flying, which no longer exists.